### PR TITLE
refactor(user): toObject removal do not delete properties

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -169,10 +169,6 @@ UserSchema.set('toJSON', {
   transform: function(doc, ret) {
     delete ret.__v;
     delete ret._id;
-    delete ret.hashpass;
-    delete ret.activator;
-    delete ret.deactivator;
-    delete ret.resetter;
     delete ret.pendingHashPass;
     delete ret.bytesDownloaded;
     delete ret.bytesUploaded;
@@ -184,10 +180,6 @@ UserSchema.set('toObject', {
   transform: function(doc, ret) {
     delete ret.__v;
     delete ret._id;
-    delete ret.hashpass;
-    delete ret.activator;
-    delete ret.deactivator;
-    delete ret.resetter;
     delete ret.pendingHashPass;
     delete ret.bytesDownloaded;
     delete ret.bytesUploaded;


### PR DESCRIPTION
Makes toObject and toJSON don't delete: hashpass, activator, deactivator and resetter from User model.